### PR TITLE
Option to keep display on when fullscreen

### DIFF
--- a/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoModule.kt
+++ b/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoModule.kt
@@ -83,8 +83,8 @@ class BlueskyVideoModule : Module() {
                     view.toggleMuted()
                 }
 
-                AsyncFunction("enterFullscreen") { view: BlueskyVideoView ->
-                    view.enterFullscreen()
+                AsyncFunction("enterFullscreen") { view: BlueskyVideoView, keepDisplayOn: Boolean ->
+                    view.enterFullscreen(keepDisplayOn)
                 }
             }
         }

--- a/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoView.kt
+++ b/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoView.kt
@@ -229,7 +229,7 @@ class BlueskyVideoView(
 
     // Fullscreen handling
 
-    fun enterFullscreen() {
+    fun enterFullscreen(keepDisplayOn: Boolean) {
         val currentActivity = this.appContext.currentActivity ?: return
 
         this.enteredFullscreenMuteState = this.isMuted
@@ -246,6 +246,7 @@ class BlueskyVideoView(
 
         // create the intent and give it a view
         val intent = Intent(context, FullscreenActivity::class.java)
+        intent.putExtra("keepDisplayOn", keepDisplayOn)
         FullscreenActivity.asscVideoView = WeakReference(this)
 
         // fire the fullscreen event and launch the intent

--- a/android/src/main/java/expo/modules/blueskyvideo/FullscreenActivity.kt
+++ b/android/src/main/java/expo/modules/blueskyvideo/FullscreenActivity.kt
@@ -30,6 +30,12 @@ class FullscreenActivity : AppCompatActivity() {
             WindowManager.LayoutParams.FLAG_FULLSCREEN,
         )
 
+        val keepDisplayOn = this.getIntent().getBooleanExtra("keepDisplayOn", false)
+
+        if (keepDisplayOn) {
+            this.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+
         // Update the player viewz
         val playerView =
             PlayerView(this).apply {

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -7,7 +7,10 @@ import {
   Platform,
   Pressable,
   SafeAreaView,
-  View
+  View,
+  Text,
+  Switch,
+  SwitchChangeEvent
 } from 'react-native'
 
 import {SAMPLE_VIDEOS} from './sampleVideos'
@@ -17,12 +20,22 @@ export default function App() {
     return [...SAMPLE_VIDEOS, ...SAMPLE_VIDEOS]
   }, [])
 
-  const renderItem = React.useCallback(({item}: ListRenderItemInfo<string>) => {
-    return <Player url={item} />
-  }, [])
+  const [fullscreenKeepDisplayOn, setFullscreenKeepDisplayOn] = React.useState<boolean>(false);
+  const toggleFullscreenKeepDisplayOn = React.useCallback((event: SwitchChangeEvent) => {
+    setFullscreenKeepDisplayOn(v => !v);
+  }, [setFullscreenKeepDisplayOn]);
+
+  const renderItem = React.useCallback(({item, index}: ListRenderItemInfo<string>) => {
+    return <Player url={item} num={index + 1} fullscreenKeepDisplayOn={fullscreenKeepDisplayOn} />
+  }, [fullscreenKeepDisplayOn])
 
   return (
     <SafeAreaView style={{flex: 1}}>
+      <Text style={{ fontWeight: 'bold' }}>Options</Text>
+      <View style={{ flexDirection: 'row' }}>
+        <Text>Keep display on when fullscreen</Text>
+        <Switch onChange={toggleFullscreenKeepDisplayOn} value={fullscreenKeepDisplayOn} />
+      </View>
       <View style={{flex: 1}}>
         <FlatList
           data={data}
@@ -38,18 +51,19 @@ export default function App() {
   )
 }
 
-function Player({url}: {url: string}) {
+function Player({url, num, fullscreenKeepDisplayOn}: {url: string, num: number, fullscreenKeepDisplayOn: boolean}) {
   const ref = React.useRef<BlueskyVideoView>(null)
 
   const onPress = () => {
     console.log('press')
-    ref.current?.enterFullscreen()
+    ref.current?.enterFullscreen(fullscreenKeepDisplayOn)
   }
 
   return (
     <Pressable
       style={{backgroundColor: 'blue', height: 300}}
       onPress={Platform.OS === 'ios' ? onPress : undefined}>
+      <Text>Video: {num}</Text>
       <BlueskyVideoView
         url={url}
         autoplay

--- a/ios/BlueskyVideoModule.swift
+++ b/ios/BlueskyVideoModule.swift
@@ -63,8 +63,8 @@ public class BlueskyVideoModule: Module {
         view.toggleMuted()
       }
 
-      AsyncFunction("enterFullscreen") { (view: VideoView) in
-        view.enterFullscreen()
+      AsyncFunction("enterFullscreen") { (view: VideoView, keepDisplayOn: Bool) in
+        view.enterFullscreen(keepDisplayOn)
       }
     }
   }

--- a/ios/VideoView.swift
+++ b/ios/VideoView.swift
@@ -77,6 +77,7 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
   private let onError = EventDispatcher()
 
   private var enteredFullScreenMuted = true
+  private var enteredFullScreenWithIdleTimerDisabled = false
   private var ignoreAutoplay = false
   private var isDestroyed = true
 
@@ -274,6 +275,9 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
         self.mute()
       }
       self.play()
+      if !self.enteredFullScreenWithIdleTimerDisabled {
+        UIApplication.shared.isIdleTimerDisabled = false
+      }
     }
   }
 
@@ -345,7 +349,7 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     }
   }
 
-  func enterFullscreen() {
+  func enterFullscreen(keepDisplayOn: Bool) {
     guard let pViewController = self.pViewController,
           !isFullscreen else {
       return
@@ -359,6 +363,10 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
       self.enteredFullScreenMuted = self.player?.isMuted ?? true
       self.unmute()
       self.isFullscreen = true
+      self.enteredFullScreenWithIdleTimerDisabled = UIApplication.shared.isIdleTimerDisabled
+      if keepDisplayOn {
+        UIApplication.shared.isIdleTimerDisabled = true
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bluesky-video",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bluesky-video",
-      "version": "0.1.10",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^18.0.25",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haileyok/bluesky-video",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "description": "A video player library for Bluesky",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/BlueskyVideoView.tsx
+++ b/src/BlueskyVideoView.tsx
@@ -22,8 +22,8 @@ export class BlueskyVideoView extends React.Component<BlueskyVideoViewProps> {
     this.ref.current?.toggleMuted()
   }
 
-  enterFullscreen = () => {
-    this.ref.current?.enterFullscreen()
+  enterFullscreen = (keepDisplayOn?: boolean) => {
+    this.ref.current?.enterFullscreen(keepDisplayOn ?? false)
   }
 
   render() {


### PR DESCRIPTION
This PR adds an argument `keepDisplayOn` to `enterFullscreen`.
* On Android, the fullscreen activity will set the `FLAG_KEEP_SCREEN_ON` flag.
* On iOS, the idle timer is disabled (`UIApplication.shared.isIdleTimerDisabled = false`)

The example app has been updated so that;
* The "keep display on" behaviour can be toggled.
* Individual videos can be more easily identified (previously it was a wall of black, save for the currently playing video).

Android has been tested (Pixel 8), iOS has not.

The intent behind this change is to keep the display on when viewing videos in fullscreen within the Bluesky mobile app.