### PR TITLE
Do not fire `onExitFullscreen` when configuration changes are being applied

### DIFF
--- a/android/src/main/java/expo/modules/blueskyvideo/FullscreenActivity.kt
+++ b/android/src/main/java/expo/modules/blueskyvideo/FullscreenActivity.kt
@@ -62,7 +62,9 @@ class FullscreenActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-        asscVideoView?.get()?.onExitFullscreen()
+        if (isChangingConfigurations() != true) {
+            asscVideoView?.get()?.onExitFullscreen()
+        }
         super.onDestroy()
     }
 }


### PR DESCRIPTION
By default Android will recreate activities (running their lifecycle methods in the process) when any of the following changes;
- Color capabilities of the screen (`colorMode`).
- Display density, such as scaling changes or moving the activity to a different screen (`density`)
- Font scaling factor (`fontScale`)
- Font weight (`fontWeightAdjustment`)
- Grammatical gender of the active language (`grammaticalGender`)
- Keyboard type, like a keyboard being plugged in (`keyboard`)
- Keyboard accessibility, such as the user revealing a builtin hardware keyboard (`keyboardHidden`)
- Layout direction, LTR and RTL (`layoutDirection`)
- Locale (`locale`)
- IMSI mobile country code (`mcc`)
- IMSI mobile network code (`mnc`)
- Navigation type, like trackball to d-pad (`navigation`)
- Screen orientation (`orientation`)
- Screen layout, possibly triggered by a different display becoming active (`screenLayout`)
- Screen size as perceived by the app (`screenSize`)
- Actual screen size (`smallestScreenSize`)
- Touchscreen (`touchscreen`)
- UI mode, such as when a device is placed in a dock, connected to a car, or night mode activation (`uiMode`)

Out of all those, `orientation` and `screenSize` are the most likely to change (they'll both change when rotating the device).

The trouble is detection of leaving full screen mode is currently handled by `onDestroy()`, which Android will invoke when recreating the activity. As a result `onExitFullscreen` is called too early which means;
- Internal state is out of sync, `isFullscreen` is set to `false`.
- If the video was muted before entering full screen (default), it is muted.
- If autoplay is disabled, the video is paused.
- The player is added back to `playerView` too early.

There are 2 ways of solving this issue;
1. Add each change type to [`android:configChanges`](https://developer.android.com/guide/topics/manifest/activity-element#config) in `AndroidManifest.xml` and handle changes ourselves.
2. Use [`isChangingConfigurations()`](https://developer.android.com/reference/android/app/Activity.html#isChangingConfigurations%28%29) to determine why lifecycle methods like `onDestroy` are being called, and only run `onExitFullscreen` when `false`.

This PR implements (2) for the following reasons;
* It is a simple 3 line change (1 of which is just an indent)
* Any configuration dependent behaviours and visuals will be automatically refreshed
* No need to update if/when a new configuration types is introduced
* `isChangingConfigurations()` is a stable API, available since API level 11 (Android 3.0).
  Granted, `android:configChanges` has been around for even longer.

This change has been tested on a Pixel 8 with Android 14.