### PR TITLE
Release without blocking parent task

### DIFF
--- a/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoView.kt
+++ b/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoView.kt
@@ -155,17 +155,19 @@ class BlueskyVideoView(
 
     private fun destroy() {
         val player = this.player ?: return
+        val playerScope = this.playerScope!!
 
         this.isLoading = false
         this.ignoreAutoplay = false
 
         this.pause()
-
-        player.release()
         this.player = null
         this.playerView.player = null
-        this.playerScope?.cancel()
         this.playerScope = null
+        playerScope.launch {
+          player.release()
+          playerScope.cancel()
+        }
     }
 
     override fun onAttachedToWindow() {


### PR DESCRIPTION
Needs some testing.

## Before

It happens during the long frame when we're creating other views etc.

<img width="802" alt="Screenshot 2024-11-24 at 19 22 24" src="https://github.com/user-attachments/assets/9ddd41af-a2ca-4100-8314-47a79df2975f">


## After

Happens later in its own frame.

<img width="949" alt="Screenshot 2024-11-24 at 19 36 47" src="https://github.com/user-attachments/assets/6e7497e3-a9e2-4851-bbb6-95b8b5181f82">
