### PR TITLE
Handle insets on android 15

### DIFF
--- a/android/src/main/java/expo/modules/blueskyvideo/FullscreenActivity.kt
+++ b/android/src/main/java/expo/modules/blueskyvideo/FullscreenActivity.kt
@@ -1,8 +1,12 @@
 package expo.modules.blueskyvideo
 
 import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
+import android.view.View
 import android.view.ViewGroup
+import android.view.WindowInsets
+import android.view.WindowInsetsController
 import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.media3.common.util.UnstableApi
@@ -25,37 +29,54 @@ class FullscreenActivity : AppCompatActivity() {
             return
         }
 
-        this.window.setFlags(
-            WindowManager.LayoutParams.FLAG_FULLSCREEN,
-            WindowManager.LayoutParams.FLAG_FULLSCREEN,
-        )
-
-        val keepDisplayOn = this.getIntent().getBooleanExtra("keepDisplayOn", false)
-
-        if (keepDisplayOn) {
-            this.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        // Enable full-screen mode for older Android versions while avoiding double insets
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            @Suppress("DEPRECATION")
+            window.decorView.systemUiVisibility = (
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                        or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                        or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+            )
+        } else {
+            window.setDecorFitsSystemWindows(false)
         }
 
-        // Update the player viewz
-        val playerView =
-            PlayerView(this).apply {
-                setBackgroundColor(Color.BLACK)
-                setShowSubtitleButton(true)
-                setShowNextButton(false)
-                setShowPreviousButton(false)
-                setFullscreenButtonClickListener {
-                    finish()
-                }
+        // Keep screen on if requested
+        val keepDisplayOn = this.intent.getBooleanExtra("keepDisplayOn", false)
+        if (keepDisplayOn) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
 
-                layoutParams =
-                    ViewGroup.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                    )
-                useController = true
-                controllerAutoShow = false
-                controllerHideOnTouch = true
+        // Update the player view with conditional insets
+        val playerView = PlayerView(this).apply {
+            setBackgroundColor(Color.BLACK)
+            setShowSubtitleButton(true)
+            setShowNextButton(false)
+            setShowPreviousButton(false)
+            setFullscreenButtonClickListener {
+                finish()
             }
+
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+            useController = true
+            controllerAutoShow = false
+            controllerHideOnTouch = true
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                // Apply padding dynamically for modern Android
+                setOnApplyWindowInsetsListener { _, insets ->
+                    val systemInsets = insets.getInsets(android.view.WindowInsets.Type.systemBars())
+                    setPadding(0, systemInsets.top, 0, systemInsets.bottom)
+                    insets
+                }
+            } else {
+                // Apply fixed padding for older Android versions
+                setPadding(0, getStatusBarHeight(), 0, getNavigationBarHeight())
+            }
+        }
         playerView.player = player
 
         setContentView(playerView)
@@ -66,5 +87,16 @@ class FullscreenActivity : AppCompatActivity() {
             asscVideoView?.get()?.onExitFullscreen()
         }
         super.onDestroy()
+    }
+
+    // Helper methods to calculate insets for status bar and navigation bar
+    private fun getStatusBarHeight(): Int {
+        val resourceId = resources.getIdentifier("status_bar_height", "dimen", "android")
+        return if (resourceId > 0) resources.getDimensionPixelSize(resourceId) else 0
+    }
+
+    private fun getNavigationBarHeight(): Int {
+        val resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
+        return if (resourceId > 0) resources.getDimensionPixelSize(resourceId) else 0
     }
 }

--- a/android/src/main/java/expo/modules/blueskyvideo/FullscreenActivity.kt
+++ b/android/src/main/java/expo/modules/blueskyvideo/FullscreenActivity.kt
@@ -6,9 +6,10 @@ import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowInsets
-import android.view.WindowInsetsController
 import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.PlayerView
 import java.lang.ref.WeakReference
@@ -29,25 +30,9 @@ class FullscreenActivity : AppCompatActivity() {
             return
         }
 
-        // Enable full-screen mode for older Android versions while avoiding double insets
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-            @Suppress("DEPRECATION")
-            window.decorView.systemUiVisibility = (
-                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                        or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                        or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-            )
-        } else {
-            window.setDecorFitsSystemWindows(false)
-        }
+        // Enable edge-to-edge mode but keep navigation bar persistent
+        WindowCompat.setDecorFitsSystemWindows(window, false)
 
-        // Keep screen on if requested
-        val keepDisplayOn = this.intent.getBooleanExtra("keepDisplayOn", false)
-        if (keepDisplayOn) {
-            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        }
-
-        // Update the player view with conditional insets
         val playerView = PlayerView(this).apply {
             setBackgroundColor(Color.BLACK)
             setShowSubtitleButton(true)
@@ -56,7 +41,6 @@ class FullscreenActivity : AppCompatActivity() {
             setFullscreenButtonClickListener {
                 finish()
             }
-
             layoutParams = ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT
@@ -64,22 +48,31 @@ class FullscreenActivity : AppCompatActivity() {
             useController = true
             controllerAutoShow = false
             controllerHideOnTouch = true
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                // Apply padding dynamically for modern Android
-                setOnApplyWindowInsetsListener { _, insets ->
-                    val systemInsets = insets.getInsets(android.view.WindowInsets.Type.systemBars())
-                    setPadding(0, systemInsets.top, 0, systemInsets.bottom)
-                    insets
-                }
-            } else {
-                // Apply fixed padding for older Android versions
-                setPadding(0, getStatusBarHeight(), 0, getNavigationBarHeight())
-            }
         }
         playerView.player = player
-
         setContentView(playerView)
+
+        // Adjust layout for system insets to accommodate persistent nav bar
+        ViewCompat.setOnApplyWindowInsetsListener(playerView) { view, insets ->
+            val systemBarsInsets = insets.getInsets(WindowInsets.Type.systemBars())
+            view.setPadding(0, systemBarsInsets.top, 0, systemBarsInsets.bottom)
+            insets
+        }
+
+        // Prevent hiding of the navigation bar
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            window.insetsController?.let {
+                it.systemBarsBehavior = android.view.WindowInsetsController.BEHAVIOR_DEFAULT
+            }
+        } else {
+            @Suppress("DEPRECATION")
+            window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+        }
+
+        val keepDisplayOn = this.intent.getBooleanExtra("keepDisplayOn", false)
+        if (keepDisplayOn) {
+            this.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
     }
 
     override fun onDestroy() {
@@ -87,16 +80,5 @@ class FullscreenActivity : AppCompatActivity() {
             asscVideoView?.get()?.onExitFullscreen()
         }
         super.onDestroy()
-    }
-
-    // Helper methods to calculate insets for status bar and navigation bar
-    private fun getStatusBarHeight(): Int {
-        val resourceId = resources.getIdentifier("status_bar_height", "dimen", "android")
-        return if (resourceId > 0) resources.getDimensionPixelSize(resourceId) else 0
-    }
-
-    private fun getNavigationBarHeight(): Int {
-        val resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
-        return if (resourceId > 0) resources.getDimensionPixelSize(resourceId) else 0
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bluesky-video",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bluesky-video",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^18.0.25",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haileyok/bluesky-video",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A video player library for Bluesky",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
Android 15 defaults to edge-to-edge mode, which means the nav bar was rendering over the controls in fullscreen mode. This PR fixes it while keeping previous versions unchanged