### PR TITLE
[Android] Stop players when backgrounded

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,4 @@ __tests__
 /android/src/test/
 /android/build/
 /example/
+moveIt.sh

--- a/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoModule.kt
+++ b/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoModule.kt
@@ -12,15 +12,9 @@ import expo.modules.kotlin.modules.ModuleDefinition
 class BlueskyVideoModule : Module() {
     companion object {
         lateinit var audioFocusManager: AudioFocusManager
-        var isAppInBackground: Boolean = false
     }
 
-    private var savedPlayerStates: MutableMap<BlueskyVideoView, PlayerState> = mutableMapOf()
-
-    data class PlayerState(
-        val isPlaying: Boolean,
-        val isMuted: Boolean
-    )
+    private var wasPlaying = false
 
     override fun definition() =
         ModuleDefinition {
@@ -31,36 +25,12 @@ class BlueskyVideoModule : Module() {
             }
 
             OnActivityEntersForeground {
-                isAppInBackground = false
-
-                savedPlayerStates.entries.toList().forEach { (view, state) ->
-                    view.restorePlayerState(state)
-                }
-                savedPlayerStates.clear()
-
-                ViewManager.onAppForegrounded()
+                ViewManager.getActiveView()?.onAppForegrounded(wasPlaying)
+                wasPlaying = false
             }
 
             OnActivityEntersBackground {
-                isAppInBackground = true
-                ViewManager.onAppBackgrounded()
-
-                // Don't destroy players if any view is in fullscreen mode
-                val hasFullscreenView = ViewManager.getAllViews().any { it.isFullscreen }
-                if (!hasFullscreenView) {
-                    savedPlayerStates.clear()
-
-                    ViewManager.getAllViews().forEach { view ->
-                        view.player?.let { player ->
-                            val state = PlayerState(
-                                isPlaying = player.isPlaying,
-                                isMuted = view.isMuted
-                            )
-                            savedPlayerStates[view] = state
-                        }
-                        view.destroyForBackground()
-                    }
-                }
+                wasPlaying = ViewManager.getActiveView()?.onAppBackgrounded() ?: false
             }
 
             AsyncFunction("updateActiveVideoViewAsync") {

--- a/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoView.kt
+++ b/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoView.kt
@@ -63,7 +63,7 @@ class BlueskyVideoView(
             )
         }
 
-    var isMuted: Boolean = true
+    private var isMuted: Boolean = true
         set(value) {
             field = value
             onMutedChange(
@@ -175,37 +175,28 @@ class BlueskyVideoView(
         this.playerScope = null
     }
 
-    fun destroyForBackground() {
-        this.removeProgressTracker()
-        this.destroy()
+    internal fun onAppBackgrounded(): Boolean {
+        val player = this.player ?: return false
+        val wasPlaying = player.isPlaying
+        this.pause()
+        if (!this.isFullscreen) {
+            this.mute()
+            player.stop()
+        }
+        return wasPlaying
     }
 
-    fun restorePlayerState(state: BlueskyVideoModule.PlayerState) {
-        if (BlueskyVideoModule.isAppInBackground) {
-            return
-        }
-
-        this.isViewActive = true
-
-        this.setup()
-
-        this.player?.let { player ->
-            val listener = object : Player.Listener {
-                override fun onPlaybackStateChanged(playbackState: Int) {
-                    if (playbackState == Player.STATE_READY) {
-                        player.removeListener(this)
-
-                        if (!state.isMuted) {
-                            this@BlueskyVideoView.unmute()
-                        }
-
-                        if (state.isPlaying) {
-                            this@BlueskyVideoView.play()
-                        }
-                    }
-                }
+    internal fun onAppForegrounded(wasPlaying: Boolean) {
+        val player = this.player ?: return
+        if (player.playbackState == Player.STATE_IDLE) {
+            // Was stopped — re-prepare. Autoplay listener handles playback.
+            if (wasPlaying) {
+                this.ignoreAutoplay = true
             }
-            player.addListener(listener)
+            player.prepare()
+        } else if (wasPlaying) {
+            // Was paused (e.g. fullscreen) — just resume.
+            this.play()
         }
     }
 
@@ -235,10 +226,6 @@ class BlueskyVideoView(
     }
 
     fun togglePlayback() {
-        if (BlueskyVideoModule.isAppInBackground) {
-            return
-        }
-
         if (this.isPlaying) {
             this.pause()
         } else {
@@ -275,10 +262,6 @@ class BlueskyVideoView(
     // Fullscreen handling
 
     fun enterFullscreen(keepDisplayOn: Boolean) {
-        if (BlueskyVideoModule.isAppInBackground) {
-            return
-        }
-
         val currentActivity = this.appContext.currentActivity ?: return
 
         this.enteredFullscreenMuteState = this.isMuted
@@ -327,7 +310,7 @@ class BlueskyVideoView(
 
         this.isViewActive = isActive
         if (isActive) {
-            if (!BlueskyVideoModule.isAppInBackground && (this.autoplay || this.forceTakeover)) {
+            if (this.autoplay || this.forceTakeover) {
                 this.setup()
             }
         } else {

--- a/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoView.kt
+++ b/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoView.kt
@@ -35,6 +35,7 @@ class BlueskyVideoView(
     var player: ExoPlayer? = null
 
     private var progressTracker: ProgressTracker? = null
+    private var isRecoveringFromBackground = false
 
     var url: Uri? = null
     var autoplay = false
@@ -46,7 +47,7 @@ class BlueskyVideoView(
             field = value
             this.playerView.useController = value
 
-            onStatusChange(
+            onFullscreenChange(
                 mapOf(
                     "isFullscreen" to value,
                 )
@@ -176,27 +177,38 @@ class BlueskyVideoView(
     }
 
     internal fun onAppBackgrounded(): Boolean {
+        if (this.isFullscreen) return false
         val player = this.player ?: return false
         val wasPlaying = player.isPlaying
         this.pause()
-        if (!this.isFullscreen) {
-            this.mute()
-            player.stop()
-        }
+        this.mute()
+        player.stop()
         return wasPlaying
     }
 
     internal fun onAppForegrounded(wasPlaying: Boolean) {
+        if (this.isFullscreen) return
         val player = this.player ?: return
         if (player.playbackState == Player.STATE_IDLE) {
-            // Was stopped — re-prepare. Autoplay listener handles playback.
-            if (wasPlaying) {
-                this.ignoreAutoplay = true
+            this.isLoading = true
+            this.isRecoveringFromBackground = true
+
+            val shouldPlay = wasPlaying || this.autoplay
+            val listener = object : Player.Listener {
+                override fun onRenderedFirstFrame() {
+                    player.removeListener(this)
+                    this@BlueskyVideoView.isRecoveringFromBackground = false
+                    this@BlueskyVideoView.isLoading = false
+                    if (shouldPlay) {
+                        this@BlueskyVideoView.play()
+                        if (!this@BlueskyVideoView.beginMuted) {
+                            this@BlueskyVideoView.unmute()
+                        }
+                    }
+                }
             }
+            player.addListener(listener)
             player.prepare()
-        } else if (wasPlaying) {
-            // Was paused (e.g. fullscreen) — just resume.
-            this.play()
         }
     }
 
@@ -214,15 +226,13 @@ class BlueskyVideoView(
     // Controls
 
     private fun play() {
-        this.addProgressTracker()
-        this.player?.play()
         this.isPlaying = true
+        this.player?.play()
     }
 
     private fun pause() {
-        this.player?.pause()
-        this.removeProgressTracker()
         this.isPlaying = false
+        this.player?.pause()
     }
 
     fun togglePlayback() {
@@ -299,6 +309,11 @@ class BlueskyVideoView(
         if (!this.autoplay && this.isPlaying) {
             this.pause()
         }
+
+        // Restore progress tracker now that playerView has a player again
+        if (this.player?.isPlaying == true) {
+            this.addProgressTracker()
+        }
     }
 
     // Visibility
@@ -372,7 +387,7 @@ class BlueskyVideoView(
                             when (playbackState) {
                                 ExoPlayer.STATE_READY -> {
                                     val view = this@BlueskyVideoView
-                                    if (view.autoplay || view.ignoreAutoplay) {
+                                    if (!view.isRecoveringFromBackground && (view.autoplay || view.ignoreAutoplay)) {
                                         view.isLoading = false
                                         view.play()
                                         if (!view.beginMuted) {
@@ -380,6 +395,18 @@ class BlueskyVideoView(
                                         }
                                     }
                                 }
+                            }
+                        }
+
+                        override fun onIsPlayingChanged(isPlaying: Boolean) {
+                            val view = this@BlueskyVideoView
+                            if (view.isPlaying != isPlaying) {
+                                view.isPlaying = isPlaying
+                            }
+                            if (isPlaying) {
+                                view.addProgressTracker()
+                            } else {
+                                view.removeProgressTracker()
                             }
                         }
                     },

--- a/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoView.kt
+++ b/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoView.kt
@@ -7,6 +7,7 @@ import android.graphics.Rect
 import android.net.Uri
 import android.view.ViewGroup
 import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
@@ -195,16 +196,24 @@ class BlueskyVideoView(
 
             val shouldPlay = wasPlaying || this.autoplay
             val listener = object : Player.Listener {
-                override fun onRenderedFirstFrame() {
+                private fun cleanup() {
                     player.removeListener(this)
                     this@BlueskyVideoView.isRecoveringFromBackground = false
                     this@BlueskyVideoView.isLoading = false
+                }
+
+                override fun onRenderedFirstFrame() {
+                    cleanup()
                     if (shouldPlay) {
                         this@BlueskyVideoView.play()
                         if (!this@BlueskyVideoView.beginMuted) {
                             this@BlueskyVideoView.unmute()
                         }
                     }
+                }
+
+                override fun onPlayerError(error: PlaybackException) {
+                    cleanup()
                 }
             }
             player.addListener(listener)

--- a/android/src/main/java/expo/modules/blueskyvideo/FullscreenActivity.kt
+++ b/android/src/main/java/expo/modules/blueskyvideo/FullscreenActivity.kt
@@ -75,6 +75,26 @@ class FullscreenActivity : AppCompatActivity() {
         }
     }
 
+    private var wasPlaying = false
+
+    override fun onStop() {
+        super.onStop()
+        if (!isChangingConfigurations && !isFinishing) {
+            asscVideoView?.get()?.player?.let { player ->
+                wasPlaying = player.isPlaying
+                player.pause()
+            }
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        if (wasPlaying) {
+            asscVideoView?.get()?.player?.play()
+            wasPlaying = false
+        }
+    }
+
     override fun onDestroy() {
         if (isChangingConfigurations() != true) {
             asscVideoView?.get()?.onExitFullscreen()

--- a/android/src/main/java/expo/modules/blueskyvideo/ViewManager.kt
+++ b/android/src/main/java/expo/modules/blueskyvideo/ViewManager.kt
@@ -9,6 +9,7 @@ class ViewManager {
         private val views = mutableSetOf<BlueskyVideoView>()
         private var currentlyActiveView: BlueskyVideoView? = null
         private var prevCount = 0
+        private var isAppInBackground = false
 
         fun addView(view: BlueskyVideoView) {
             views.add(view)
@@ -24,6 +25,11 @@ class ViewManager {
         }
 
         fun updateActiveView() {
+            // Don't update active view when app is backgrounded
+            if (isAppInBackground) {
+                return
+            }
+            
             var activeView: BlueskyVideoView? = null
             val count = views.count()
 
@@ -86,5 +92,17 @@ class ViewManager {
         }
 
         fun getActiveView(): BlueskyVideoView? = currentlyActiveView
+        
+        fun getAllViews(): Set<BlueskyVideoView> = views.toSet()
+        
+        fun onAppBackgrounded() {
+            isAppInBackground = true
+            clearActiveView()
+        }
+        
+        fun onAppForegrounded() {
+            isAppInBackground = false
+            updateActiveView()
+        }
     }
 }

--- a/android/src/main/java/expo/modules/blueskyvideo/ViewManager.kt
+++ b/android/src/main/java/expo/modules/blueskyvideo/ViewManager.kt
@@ -9,7 +9,6 @@ class ViewManager {
         private val views = mutableSetOf<BlueskyVideoView>()
         private var currentlyActiveView: BlueskyVideoView? = null
         private var prevCount = 0
-        private var isAppInBackground = false
 
         fun addView(view: BlueskyVideoView) {
             views.add(view)
@@ -25,11 +24,6 @@ class ViewManager {
         }
 
         fun updateActiveView() {
-            // Don't update active view when app is backgrounded
-            if (isAppInBackground) {
-                return
-            }
-            
             var activeView: BlueskyVideoView? = null
             val count = views.count()
 
@@ -92,17 +86,5 @@ class ViewManager {
         }
 
         fun getActiveView(): BlueskyVideoView? = currentlyActiveView
-        
-        fun getAllViews(): Set<BlueskyVideoView> = views.toSet()
-        
-        fun onAppBackgrounded() {
-            isAppInBackground = true
-            clearActiveView()
-        }
-        
-        fun onAppForegrounded() {
-            isAppInBackground = false
-            updateActiveView()
-        }
     }
 }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,5 @@
-import {BlueskyVideoView} from 'bluesky-video'
-import {updateActiveVideoViewAsync} from 'bluesky-video/BlueskyVideoModule'
+import {BlueskyVideoView} from '@bsky.app/video'
+import {updateActiveVideoViewAsync} from '@bsky.app/video/BlueskyVideoModule'
 import React from 'react'
 import {
   FlatList,
@@ -10,7 +10,9 @@ import {
   View,
   Text,
   Switch,
-  SwitchChangeEvent
+  SwitchChangeEvent,
+  ActivityIndicator,
+  StyleSheet
 } from 'react-native'
 
 import {SAMPLE_VIDEOS} from './sampleVideos'
@@ -107,6 +109,7 @@ function Player({
 }) {
   const ref = React.useRef<BlueskyVideoView>(null)
   const [active, setActive] = React.useState(false)
+  const [isLoading, setIsLoading] = React.useState(false)
 
   const onPress = () => {
     console.log('press')
@@ -132,18 +135,25 @@ function Player({
         onStatusChange={e => {
           console.log('status', e.nativeEvent.status)
         }}
+        onFullscreenChange={e => {
+          console.log('fullscreen', e.nativeEvent.isFullscreen)
+        }}
         onActiveChange={e => {
           console.log('active', e.nativeEvent.isActive)
           setActive(e.nativeEvent.isActive)
         }}
         onLoadingChange={e => {
           console.log('loading', e.nativeEvent.isLoading)
+          setIsLoading(e.nativeEvent.isLoading)
         }}
         onTimeRemainingChange={e => {
           console.log('timeRemaining', e.nativeEvent.timeRemaining)
         }}
         onPlayerPress={Platform.OS === 'android' ? onPress : undefined}
       />
+      {isLoading && (
+        <ActivityIndicator style={StyleSheet.absoluteFill} size="large" />
+      )}
     </Pressable>
   )
 }

--- a/example/package.json
+++ b/example/package.json
@@ -3,13 +3,14 @@
   "version": "1.0.0",
   "main": "expo/AppEntry.js",
   "scripts": {
-    "start": "expo start",
+    "start": "expo start --dev-client",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "prebuild": "EXPO_NO_GIT_STATUS=1 expo prebuild --clean"
   },
   "dependencies": {
-    "expo": "^54.0.32",
+    "expo": "54.0.33",
     "react": "19.1.0",
     "react-native": "0.81.5"
   },

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -880,10 +880,10 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
 
-"@expo/cli@54.0.22":
-  version "54.0.22"
-  resolved "https://registry.yarnpkg.com/@expo/cli/-/cli-54.0.22.tgz#e686cfb7238e0bc2afcbf65140239b3c08030961"
-  integrity sha512-BTH2FCczhJLfj1cpfcKrzhKnvRLTOztgW4bVloKDqH+G3ZSohWLRFNAIz56XtdjPxBbi2/qWhGBAkl7kBon/Jw==
+"@expo/cli@54.0.23":
+  version "54.0.23"
+  resolved "https://registry.yarnpkg.com/@expo/cli/-/cli-54.0.23.tgz#e8a7dc4e1f2a8a5361afd80bcc352014b57a87ac"
+  integrity sha512-km0h72SFfQCmVycH/JtPFTVy69w6Lx1cHNDmfLfQqgKFYeeHTjx7LVDP4POHCtNxFP2UeRazrygJhlh4zz498g==
   dependencies:
     "@0no-co/graphql.web" "^1.0.8"
     "@expo/code-signing-certificates" "^0.0.6"
@@ -2432,13 +2432,13 @@ expo-server@^1.0.5:
   resolved "https://registry.yarnpkg.com/expo-server/-/expo-server-1.0.5.tgz#2d52002199a2af99c2c8771d0657916004345ca9"
   integrity sha512-IGR++flYH70rhLyeXF0Phle56/k4cee87WeQ4mamS+MkVAVP+dDlOHf2nN06Z9Y2KhU0Gp1k+y61KkghF7HdhA==
 
-expo@^54.0.32:
-  version "54.0.32"
-  resolved "https://registry.yarnpkg.com/expo/-/expo-54.0.32.tgz#eda2c6e742b0f7e2f4354e280dbadf35dcd86ef7"
-  integrity sha512-yL9eTxiQ/QKKggVDAWO5CLjUl6IS0lPYgEvC3QM4q4fxd6rs7ks3DnbXSGVU3KNFoY/7cRNYihvd0LKYP+MCXA==
+expo@54.0.33:
+  version "54.0.33"
+  resolved "https://registry.yarnpkg.com/expo/-/expo-54.0.33.tgz#f7d572857323f5a8250a9afe245a487d2ee2735f"
+  integrity sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==
   dependencies:
     "@babel/runtime" "^7.20.0"
-    "@expo/cli" "54.0.22"
+    "@expo/cli" "54.0.23"
     "@expo/config" "~12.0.13"
     "@expo/config-plugins" "~54.0.4"
     "@expo/devtools" "0.1.8"

--- a/moveIt.sh
+++ b/moveIt.sh
@@ -1,2 +1,2 @@
 #! /bin/sh
-yarn prepare && rm -Rf ../social-app/node_modules/bluesky-video && cp -R . ../social-app/node_modules/bluesky-video
+yarn prepare && rm -Rf ../social-app/node_modules/@bsky.app/bluesky-video && cp -R . ../social-app/node_modules/@bsky.app/bluesky-video

--- a/moveIt.sh
+++ b/moveIt.sh
@@ -1,2 +1,2 @@
 #! /bin/sh
-yarn prepare && rm -Rf ../social-app/node_modules/@bsky.app/bluesky-video && cp -R . ../social-app/node_modules/@bsky.app/bluesky-video
+yarn prepare && rm -Rf ../social-app/node_modules/@bsky.app/video && cp -R . ../social-app/node_modules/@bsky.app/video

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsky.app/video",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A video player library for Bluesky",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/BlueskyVideo.types.ts
+++ b/src/BlueskyVideo.types.ts
@@ -3,7 +3,7 @@ import {NativeSyntheticEvent, StyleProp, ViewStyle} from 'react-native'
 export type BlueskyVideoViewProps = {
   url: string
   autoplay: boolean
-  beginMuted: boolean
+  beginMuted?: boolean
   forceTakeover?: boolean
   accessibilityHint?: string
   accessibilityLabel?: string


### PR DESCRIPTION
## Summary
- **Background (inline):** Uses `player.stop()` to release network/decoder resources while keeping the player instance. On foreground, `player.prepare()` re-buffers and waits for the first rendered frame before starting playback, so audio and video start in sync. Emits loading events during recovery.
- **Background (fullscreen):** Pauses the player via `FullscreenActivity.onStop`/`onStart`. Player stays prepared so resume is instant.
- **Bug fixes:**
  - `onFullscreenChange` event was incorrectly firing through `onStatusChange` on Android (iOS was correct)
  - Progress tracker now properly stops when paused via fullscreen controls or backgrounding
  - `onExitFullscreen` no longer redundantly restarts playback for autoplay videos
  - `addProgressTracker` removes existing tracker first to prevent duplicate timers

## Approach

Previous version fully destroyed and recreated players on background. This was over-engineered — `player.stop()` releases the same resources without the complexity of save/restore state management. The inline background/foreground flow now piggybacks on ExoPlayer's existing prepare/autoplay mechanism.

Fullscreen is handled separately in `FullscreenActivity` since Expo's `OnActivityEntersBackground` is tied to the host activity, not the process — it fires when *entering* fullscreen, not when actually backgrounding.

## Test plan
- [ ] Play video inline, background app, foreground — video should show loading then resume
- [ ] Play video in fullscreen, background app, foreground — video should resume from same position
- [ ] Exit fullscreen normally — video should keep playing (autoplay) or pause (non-autoplay)
- [ ] Pause video in fullscreen via controls — progress tracker should stop
- [ ] Verify no audio plays before video is visible when recovering from background