### PR TITLE
Fix iOS video visibility/early destroy issue

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -117,7 +117,7 @@ function Player({
       style={{
         backgroundColor: 'blue',
         height: 300,
-        marginBottom: gaps ? 150 : 0
+        marginBottom: gaps ? 300 : 0
       }}
       onPress={Platform.OS === 'ios' ? onPress : undefined}>
       <Text>Video: {num}</Text>

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -106,6 +106,7 @@ function Player({
   gaps: boolean
 }) {
   const ref = React.useRef<BlueskyVideoView>(null)
+  const [active, setActive] = React.useState(false)
 
   const onPress = () => {
     console.log('press')
@@ -115,9 +116,9 @@ function Player({
   return (
     <Pressable
       style={{
-        backgroundColor: 'blue',
+        backgroundColor: active ? 'green' : 'gray',
         height: 300,
-        marginBottom: gaps ? 300 : 0
+        marginBottom: gaps ? 400 : 0
       }}
       onPress={Platform.OS === 'ios' ? onPress : undefined}>
       <Text>Video: {num}</Text>
@@ -130,6 +131,10 @@ function Player({
         }}
         onStatusChange={e => {
           console.log('status', e.nativeEvent.status)
+        }}
+        onActiveChange={e => {
+          console.log('active', e.nativeEvent.isActive)
+          setActive(e.nativeEvent.isActive)
         }}
         onLoadingChange={e => {
           console.log('loading', e.nativeEvent.isLoading)

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -22,11 +22,19 @@ export default function App() {
 
   const [fullscreenKeepDisplayOn, setFullscreenKeepDisplayOn] =
     React.useState<boolean>(false)
+  const [gaps, setGaps] = React.useState<boolean>(false)
   const toggleFullscreenKeepDisplayOn = React.useCallback(
     (event: SwitchChangeEvent) => {
       setFullscreenKeepDisplayOn(v => !v)
     },
     [setFullscreenKeepDisplayOn]
+  )
+
+  const toggleGaps = React.useCallback(
+    (event: SwitchChangeEvent) => {
+      setGaps(v => !v)
+    },
+    [setGaps]
   )
 
   const renderItem = React.useCallback(
@@ -36,10 +44,11 @@ export default function App() {
           url={item}
           num={index + 1}
           fullscreenKeepDisplayOn={fullscreenKeepDisplayOn}
+          gaps={gaps}
         />
       )
     },
-    [fullscreenKeepDisplayOn]
+    [fullscreenKeepDisplayOn, gaps]
   )
 
   // @ts-ignore
@@ -48,7 +57,21 @@ export default function App() {
   return (
     <SafeAreaView style={{flex: 1}}>
       <Text style={{fontWeight: 'bold'}}>Options</Text>
-      <View style={{flexDirection: 'row'}}>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between'
+        }}>
+        <Text>Add gaps between videos</Text>
+        <Switch onChange={toggleGaps} value={gaps} />
+      </View>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between'
+        }}>
         <Text>Keep display on when fullscreen</Text>
         <Switch
           onChange={toggleFullscreenKeepDisplayOn}
@@ -74,11 +97,13 @@ export default function App() {
 function Player({
   url,
   num,
-  fullscreenKeepDisplayOn
+  fullscreenKeepDisplayOn,
+  gaps
 }: {
   url: string
   num: number
   fullscreenKeepDisplayOn: boolean
+  gaps: boolean
 }) {
   const ref = React.useRef<BlueskyVideoView>(null)
 
@@ -89,7 +114,11 @@ function Player({
 
   return (
     <Pressable
-      style={{backgroundColor: 'blue', height: 300}}
+      style={{
+        backgroundColor: 'blue',
+        height: 300,
+        marginBottom: gaps ? 150 : 0
+      }}
       onPress={Platform.OS === 'ios' ? onPress : undefined}>
       <Text>Video: {num}</Text>
       <BlueskyVideoView

--- a/ios/PlayerManager.swift
+++ b/ios/PlayerManager.swift
@@ -10,11 +10,11 @@ import AVFoundation
 class PlayerManager {
   static let shared = PlayerManager()
 
-  private var availalbePlayers: [AVPlayer] = []
+  private var availablePlayers: [AVPlayer] = []
   private var usedPlayers: Set<AVPlayer> = []
 
   func dequeuePlayer() -> AVPlayer {
-    if let player = availalbePlayers.popLast() {
+    if let player = availablePlayers.popLast() {
       self.usedPlayers.insert(player)
       return player
     } else {
@@ -28,7 +28,7 @@ class PlayerManager {
   func recyclePlayer(_ player: AVPlayer) {
     self.resetPlayer(player)
     self.usedPlayers.remove(player)
-    self.availalbePlayers.append(player)
+    self.availablePlayers.append(player)
   }
 
   private func resetPlayer(_ player: AVPlayer) {
@@ -48,7 +48,7 @@ class PlayerManager {
   }
 
   func allPlayers() -> [AVPlayer] {
-    return Array(self.usedPlayers) + self.availalbePlayers
+    return Array(self.usedPlayers) + self.availablePlayers
   }
 }
 

--- a/ios/ViewManager.swift
+++ b/ios/ViewManager.swift
@@ -58,8 +58,7 @@ class ViewManager: Manager<VideoView> {
             return
           }
 
-          let visibilityPercentage = self.calculateVisibilityPercentage(
-            view: view, position: position)
+          let visibilityPercentage = view.calculateVisibilityPercentage()
 
           // Only consider videos that meet the minimum visibility threshold
           if visibilityPercentage >= 0.5 {
@@ -89,22 +88,6 @@ class ViewManager: Manager<VideoView> {
     }
   }
 
-  private func calculateVisibilityPercentage(view: VideoView, position: CGRect) -> CGFloat {
-    guard let window = view.window else {
-      return 0
-    }
-
-    // Create screen bounds with 150px top margin to account for fixed header
-    var screenBounds = window.bounds
-    screenBounds.origin.y += 100
-    screenBounds.size.height -= 100
-
-    let intersection = position.intersection(screenBounds)
-    let viewArea = position.width * position.height
-    let visibleArea = intersection.width * intersection.height
-
-    return viewArea > 0 ? visibleArea / viewArea : 0
-  }
 
   private func clearActiveView() {
     if let currentlyActiveView = self.currentlyActiveView {

--- a/package.json
+++ b/package.json
@@ -93,5 +93,6 @@
     "arrowParens": "avoid",
     "bracketSameLine": true,
     "bracketSpacing": false
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Basically we use a new algorithm for selecting the active video

  - We now calculate the % visibility of each video
  - Video with highest visibility percentage is picked
  - Tie-breaking by position - when visibility is equal, selects topmost video
  - 150px boundary is now moved into the bounds of the percentage visible calculation - previously a logic error would discard any video above that bound

Seems a lot more consistent in the example app - adding gaps makes it a more realistic simulation of a bsky feed

https://github.com/user-attachments/assets/020d636c-5374-4164-9b0c-dbda799b8a4a

