### PR TITLE
Add video staging system to iOS

### DIFF
--- a/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoView.kt
+++ b/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoView.kt
@@ -86,9 +86,11 @@ class BlueskyVideoView(
     private var isViewActive: Boolean = false
         set(value) {
             field = value
+            val state = if (value) "active" else "inactive"
             onActiveChange(
                 mapOf(
-                    "state" to if (value) "active" else "inactive",
+                    "isActive" to (state == "active"),
+                    "state" to state,
                 ),
             )
         }

--- a/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoView.kt
+++ b/android/src/main/java/expo/modules/blueskyvideo/BlueskyVideoView.kt
@@ -88,7 +88,7 @@ class BlueskyVideoView(
             field = value
             onActiveChange(
                 mapOf(
-                    "isActive" to value,
+                    "state" to if (value) "active" else "inactive",
                 ),
             )
         }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -106,7 +106,7 @@ function Player({
   gaps: boolean
 }) {
   const ref = React.useRef<BlueskyVideoView>(null)
-  const [active, setActive] = React.useState(false)
+  const [active, setActive] = React.useState('inactive')
 
   const onPress = () => {
     console.log('press')
@@ -116,7 +116,12 @@ function Player({
   return (
     <Pressable
       style={{
-        backgroundColor: active ? 'green' : 'gray',
+        backgroundColor:
+          active === 'active'
+            ? 'green'
+            : active === 'staged'
+              ? 'yellow'
+              : 'gray',
         height: 300,
         marginBottom: gaps ? 400 : 0
       }}
@@ -133,8 +138,8 @@ function Player({
           console.log('status', e.nativeEvent.status)
         }}
         onActiveChange={e => {
-          console.log('active', e.nativeEvent.isActive)
-          setActive(e.nativeEvent.isActive)
+          console.log('active', e.nativeEvent.state)
+          setActive(e.nativeEvent.state)
         }}
         onLoadingChange={e => {
           console.log('loading', e.nativeEvent.isLoading)

--- a/example/package.json
+++ b/example/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "expo/AppEntry.js",
   "scripts": {
-    "start": "expo start",
+    "start": "expo start --dev-client",
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web"

--- a/ios/VideoView.swift
+++ b/ios/VideoView.swift
@@ -64,7 +64,7 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     }
   }
 
-  private var isFullscreen: Bool = false {
+  var isFullscreen: Bool = false {
     didSet {
       if isFullscreen {
         self.pViewController?.showsPlaybackControls = isFullscreen

--- a/ios/VideoView.swift
+++ b/ios/VideoView.swift
@@ -121,6 +121,7 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     }
     
     self.onActiveChange([
+      "isActive": state == "active",
       "state": state
     ])
   }

--- a/ios/VideoView.swift
+++ b/ios/VideoView.swift
@@ -51,9 +51,16 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
       if isViewActive == oldValue {
         return
       }
-      self.onActiveChange([
-        "isActive": isViewActive
-      ])
+      self.emitActiveStateChange()
+    }
+  }
+
+  private var isViewStaged: Bool = false {
+    didSet {
+      if isViewStaged == oldValue {
+        return
+      }
+      self.emitActiveStateChange()
     }
   }
 
@@ -101,6 +108,21 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     self.pViewController = AVPlayerViewController()
     super.init(appContext: appContext)
     self.clipsToBounds = true
+  }
+
+  private func emitActiveStateChange() {
+    let state: String
+    if isViewActive {
+      state = "active"
+    } else if isViewStaged {
+      state = "staged"
+    } else {
+      state = "inactive"
+    }
+    
+    self.onActiveChange([
+      "state": state
+    ])
   }
 
   // MARK: - lifecycle
@@ -154,7 +176,59 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     }
   }
 
-  private func destroy() {
+  private func setupStaged() {
+    guard let url = url, self.player == nil else {
+      return
+    }
+
+    self.isDestroyed = false
+    self.isLoading = true
+
+    // Setup the view controller
+    let pViewController = AVPlayerViewController()
+    pViewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    pViewController.view.backgroundColor = .clear
+    pViewController.view.frame = self.frame
+    pViewController.showsPlaybackControls = false
+    pViewController.delegate = self
+    pViewController.videoGravity = .resizeAspectFill
+    if #available(iOS 16.0, *) {
+      pViewController.allowsVideoFrameAnalysis = false
+    }
+
+    // Recycle the current player if there is one
+    if let currentPlayer = self.player {
+      PlayerManager.shared.recyclePlayer(currentPlayer)
+    }
+
+    // Get a new player to use
+    let player = PlayerManager.shared.dequeuePlayer()
+
+    // Add observers to the player
+    self.periodicTimeObserver = self.createPeriodicTimeObserver(player)
+
+    pViewController.player = player
+    self.addSubview(pViewController.view)
+
+    self.pViewController = pViewController
+    self.player = player
+
+    // Get the player item and add it to the player with staged settings
+    DispatchQueue.global(qos: .background).async { [weak self] in
+      let playerItem = AVPlayerItem(url: url)
+      playerItem.preferredForwardBufferDuration = 1
+      playerItem.canUseNetworkResourcesForLiveStreamingWhilePaused = false
+
+      DispatchQueue.main.async {
+        self?.player?.replaceCurrentItem(with: playerItem)
+        self?.addObserversToPlayerItem(playerItem)
+        // Ensure the player is paused for staged state
+        self?.player?.pause()
+      }
+    }
+  }
+
+  func destroy() {
     self.isDestroyed = true
 
     guard let player = self.player else {
@@ -232,7 +306,7 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     if keyPath == "status" {
       if playerItem.status == AVPlayerItem.Status.readyToPlay {
         self.isLoading = false
-        if self.autoplay || self.ignoreAutoplay {
+        if self.isViewActive && (self.autoplay || self.ignoreAutoplay) {
           self.play()
 
           if !self.beginMuted {
@@ -312,19 +386,64 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
   // MARK: - visibility
 
-  func setIsCurrentlyActive(active: Bool) -> Bool {
+  func transitionToActive() -> Bool {
     if self.isFullscreen {
       return false
     }
 
-    self.isViewActive = active
-    if active {
-      if self.autoplay || self.forceTakeover {
-        self.setup()
-      }
+    self.isViewActive = true
+    self.isViewStaged = false
+    
+    if self.player == nil {
+      self.setup()
     } else {
-      self.destroy()
+      // Update player item settings for active playback
+      if let playerItem = self.player?.currentItem {
+        playerItem.preferredForwardBufferDuration = 5
+        playerItem.canUseNetworkResourcesForLiveStreamingWhilePaused = true
+      }
+      
+      if self.autoplay || self.ignoreAutoplay {
+        self.play()
+        if !self.beginMuted {
+          self.unmute()
+        }
+      }
     }
+    return true
+  }
+
+  func transitionToStaged() -> Bool {
+    if self.isFullscreen {
+      return false
+    }
+
+    self.isViewStaged = true
+    self.isViewActive = false
+    
+    if self.player == nil {
+      self.setupStaged()
+    } else {
+      // Update player item settings for staged state
+      if let playerItem = self.player?.currentItem {
+        playerItem.preferredForwardBufferDuration = 1
+        playerItem.canUseNetworkResourcesForLiveStreamingWhilePaused = false
+      }
+      self.pause()
+    }
+    return true
+  }
+
+  func transitionToInactive() -> Bool {
+    if self.isFullscreen {
+      return false
+    }
+
+    self.isViewActive = false
+    self.isViewStaged = false
+    
+    // Just pause, don't destroy (destruction happens only on view removal)
+    self.pause()
     return true
   }
 
@@ -347,7 +466,10 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
       if self.player == nil {
         ViewManager.shared.setActiveView(self)
         self.ignoreAutoplay = true
-        self.setup()
+      } else if self.isViewStaged {
+        // Promote staged video to active
+        ViewManager.shared.setActiveView(self)
+        self.ignoreAutoplay = true
       } else {
         self.play()
       }

--- a/ios/ViewManager.swift
+++ b/ios/ViewManager.swift
@@ -11,6 +11,7 @@ class ViewManager: Manager<VideoView> {
   static let shared = ViewManager()
 
   private var currentlyActiveView: VideoView?
+  private var stagedViews: [VideoView] = []
   private var screenHeight = UIScreen.main.bounds.height
   private var prevCount = 0
 
@@ -25,65 +26,96 @@ class ViewManager: Manager<VideoView> {
 
   override func remove(_ object: VideoView) {
     super.remove(object)
+    
+    // Remove from staged views if present
+    if let index = self.stagedViews.firstIndex(of: object) {
+      self.stagedViews.remove(at: index)
+    }
+    
+    // Clear active view if it's the one being removed
+    if self.currentlyActiveView == object {
+      self.currentlyActiveView = nil
+    }
+    
     self.prevCount = self.count()
   }
 
   func updateActiveView() {
     DispatchQueue.main.async {
-      var activeView: VideoView?
-
-      if self.count() == 1 {
-        // get the first one
-        guard let view = self.getEnumerator()?.nextObject() as? VideoView else {
-          return
-        }
-        if view.isViewableEnough() {
-          activeView = view
-        }
-      } else if self.count() > 1 {
-        guard let views = self.getEnumerator() else {
-          return
-        }
-
-        var mostVisibleView: VideoView?
-        var highestVisibilityPercentage: CGFloat = 0
-        var topMostPosition: CGFloat = CGFloat.greatestFiniteMagnitude
-
-        views.forEach { view in
-          guard let view = view as? VideoView else {
-            return
-          }
-
-          guard let position = view.getPositionOnScreen() else {
-            return
-          }
-
-          let visibilityPercentage = view.calculateVisibilityPercentage()
-
-          // Only consider videos that meet the minimum visibility threshold
-          if visibilityPercentage >= 0.5 {
-            // Pick the most visible video, or if tied, the topmost one
-            if visibilityPercentage > highestVisibilityPercentage
-              || (visibilityPercentage == highestVisibilityPercentage
-                && position.minY < topMostPosition)
-            {
-              mostVisibleView = view
-              highestVisibilityPercentage = visibilityPercentage
-              topMostPosition = position.minY
-            }
-          }
-        }
-
-        activeView = mostVisibleView
-      }
-
-      if activeView == self.currentlyActiveView {
+      guard let views = self.getEnumerator() else {
         return
       }
 
+      // Collect all views with their visibility info
+      var visibleViews: [(view: VideoView, visibility: CGFloat, position: CGFloat)] = []
+      
+      views.forEach { view in
+        guard let view = view as? VideoView else {
+          return
+        }
+
+        guard let position = view.getPositionOnScreen() else {
+          return
+        }
+
+        let visibilityPercentage = view.calculateVisibilityPercentage()
+
+        // Only consider videos that have any visibility (>0%)
+        if visibilityPercentage > 0 {
+          visibleViews.append((view: view, visibility: visibilityPercentage, position: position.minY))
+        }
+      }
+
+      // Sort by visibility percentage (descending), then by position (ascending for topmost)
+      visibleViews.sort { first, second in
+        if first.visibility == second.visibility {
+          return first.position < second.position
+        }
+        return first.visibility > second.visibility
+      }
+
+      // Take the top 3 visible videos
+      let topViews = Array(visibleViews.prefix(3))
+      
+      // The most visible video (≥50%) becomes active, others become staged
+      var newActiveView: VideoView?
+      var newStagedViews: [VideoView] = []
+      
+      for (index, viewInfo) in topViews.enumerated() {
+        if index == 0 && viewInfo.visibility >= 0.5 {
+          // First video with ≥50% visibility becomes active
+          newActiveView = viewInfo.view
+        } else {
+          // Other visible videos become staged
+          newStagedViews.append(viewInfo.view)
+        }
+      }
+
+      // Check if we need to update anything
+      let activeViewChanged = newActiveView != self.currentlyActiveView
+      let stagedViewsChanged = !Set(newStagedViews).isSubset(of: Set(self.stagedViews)) || 
+                               !Set(self.stagedViews).isSubset(of: Set(newStagedViews))
+
+      if !activeViewChanged && !stagedViewsChanged {
+        return
+      }
+
+      // Clear current state
       self.clearActiveView()
-      if let view = activeView {
-        self.setActiveView(view)
+      self.clearStagedViews()
+
+      // Destroy players for views that are no longer in top 3
+      let newTopViews = Set([newActiveView].compactMap { $0 } + newStagedViews)
+      self.destroyViewsNotInSet(newTopViews)
+
+      // Set new active view
+      if let activeView = newActiveView {
+        self.setActiveView(activeView)
+      }
+
+      // Set new staged views
+      for stagedView in newStagedViews {
+        self.setStagedView(stagedView)
       }
     }
   }
@@ -91,18 +123,49 @@ class ViewManager: Manager<VideoView> {
 
   private func clearActiveView() {
     if let currentlyActiveView = self.currentlyActiveView {
-      _ = currentlyActiveView.setIsCurrentlyActive(active: false)
+      _ = currentlyActiveView.transitionToInactive()
       self.currentlyActiveView = nil
     }
+  }
+
+  private func clearStagedViews() {
+    for stagedView in self.stagedViews {
+      _ = stagedView.transitionToInactive()
+    }
+    self.stagedViews.removeAll()
   }
 
   func setActiveView(_ view: VideoView) {
     if self.currentlyActiveView != nil {
       self.clearActiveView()
     }
-    let didUpdate = view.setIsCurrentlyActive(active: true)
+    let didUpdate = view.transitionToActive()
     if didUpdate {
       self.currentlyActiveView = view
+    }
+  }
+
+  func setStagedView(_ view: VideoView) {
+    let didUpdate = view.transitionToStaged()
+    if didUpdate {
+      self.stagedViews.append(view)
+    }
+  }
+
+  private func destroyViewsNotInSet(_ topViews: Set<VideoView>) {
+    guard let views = self.getEnumerator() else {
+      return
+    }
+    
+    views.forEach { view in
+      guard let view = view as? VideoView else {
+        return
+      }
+      
+      // If this view is not in the top 3, destroy its player
+      if !topViews.contains(view) {
+        view.destroy()
+      }
     }
   }
 }

--- a/ios/ViewManager.swift
+++ b/ios/ViewManager.swift
@@ -136,9 +136,24 @@ class ViewManager: Manager<VideoView> {
   }
 
   func setActiveView(_ view: VideoView) {
-    if self.currentlyActiveView != nil {
-      self.clearActiveView()
+    // If there's a current active view, demote it to staged (if there's room)
+    if let currentActive = self.currentlyActiveView, currentActive != view {
+      if self.stagedViews.count < 2 {
+        // Demote current active to staged
+        _ = currentActive.transitionToStaged()
+        self.stagedViews.append(currentActive)
+      } else {
+        // No room in staged, demote to inactive
+        _ = currentActive.transitionToInactive()
+      }
+      self.currentlyActiveView = nil
     }
+    
+    // Remove from staged views if this view was staged
+    if let index = self.stagedViews.firstIndex(of: view) {
+      self.stagedViews.remove(at: index)
+    }
+    
     let didUpdate = view.transitionToActive()
     if didUpdate {
       self.currentlyActiveView = view
@@ -159,6 +174,11 @@ class ViewManager: Manager<VideoView> {
     
     views.forEach { view in
       guard let view = view as? VideoView else {
+        return
+      }
+      
+      // Never destroy fullscreen videos
+      if view.isFullscreen {
         return
       }
       

--- a/ios/ViewManager.swift
+++ b/ios/ViewManager.swift
@@ -46,8 +46,9 @@ class ViewManager: Manager<VideoView> {
         return
       }
 
-      // Collect all views with their visibility info
-      var visibleViews: [(view: VideoView, visibility: CGFloat, position: CGFloat)] = []
+      // Collect views that are eligible (on screen or below screen)
+      var eligibleViews: [(view: VideoView, visibility: CGFloat, position: CGFloat)] = []
+      let screenHeight = UIScreen.main.bounds.height
       
       views.forEach { view in
         guard let view = view as? VideoView else {
@@ -59,23 +60,25 @@ class ViewManager: Manager<VideoView> {
         }
 
         let visibilityPercentage = view.calculateVisibilityPercentage()
+        let isOnScreen = visibilityPercentage > 0
+        let isBelowScreen = position.minY >= screenHeight
 
-        // Only consider videos that have any visibility (>0%)
-        if visibilityPercentage > 0 {
-          visibleViews.append((view: view, visibility: visibilityPercentage, position: position.minY))
+        // Include videos that are on screen OR below screen (not above screen)
+        if isOnScreen || isBelowScreen {
+          eligibleViews.append((view: view, visibility: visibilityPercentage, position: position.minY))
         }
       }
 
       // Sort by visibility percentage (descending), then by position (ascending for topmost)
-      visibleViews.sort { first, second in
+      eligibleViews.sort { first, second in
         if first.visibility == second.visibility {
           return first.position < second.position
         }
         return first.visibility > second.visibility
       }
 
-      // Take the top 3 visible videos
-      let topViews = Array(visibleViews.prefix(3))
+      // Take the top 3 eligible videos
+      let topViews = Array(eligibleViews.prefix(3))
       
       // The most visible video (≥50%) becomes active, others become staged
       var newActiveView: VideoView?

--- a/ios/ViewManager.swift
+++ b/ios/ViewManager.swift
@@ -100,23 +100,55 @@ class ViewManager: Manager<VideoView> {
         return
       }
 
-      // Clear current state
-      self.clearActiveView()
-      self.clearStagedViews()
-
-      // Destroy players for views that are no longer in top 3
+      // Calculate which views need state changes
       let newTopViews = Set([newActiveView].compactMap { $0 } + newStagedViews)
+      
+      // Destroy players for views that are no longer in top 3
       self.destroyViewsNotInSet(newTopViews)
 
+      // Build complete transition plan to avoid intermediate states
+      let newStagedSet = Set(newStagedViews)
+      let currentStagedSet = Set(self.stagedViews)
+      
+      // Handle old active view
+      if let oldActive = self.currentlyActiveView, oldActive != newActiveView {
+        if newStagedSet.contains(oldActive) {
+          // Active -> Staged: transition directly
+          _ = oldActive.transitionToStaged()
+        } else {
+          // Active -> Inactive: transition to inactive
+          _ = oldActive.transitionToInactive()
+        }
+      }
+      
+      // Handle old staged views
+      for oldStaged in currentStagedSet {
+        if oldStaged == newActiveView {
+          // Staged -> Active: will be handled below
+          continue
+        } else if !newStagedSet.contains(oldStaged) {
+          // Staged -> Inactive: transition to inactive
+          _ = oldStaged.transitionToInactive()
+        }
+        // Staged -> Staged: no change needed
+      }
+      
       // Set new active view
-      if let activeView = newActiveView {
-        self.setActiveView(activeView)
+      if let newActive = newActiveView, newActive != self.currentlyActiveView {
+        self.currentlyActiveView = newActive
+        _ = newActive.transitionToActive()
+      } else if newActiveView == nil {
+        self.currentlyActiveView = nil
       }
-
-      // Set new staged views
-      for stagedView in newStagedViews {
-        self.setStagedView(stagedView)
+      
+      // Set new staged views (only for newly staged ones)
+      for newStaged in newStagedViews {
+        if !currentStagedSet.contains(newStaged) && newStaged != self.currentlyActiveView {
+          _ = newStaged.transitionToStaged()
+        }
       }
+      
+      self.stagedViews = newStagedViews
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haileyok/bluesky-video",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A video player library for Bluesky",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/BlueskyVideo.types.ts
+++ b/src/BlueskyVideo.types.ts
@@ -8,7 +8,7 @@ export type BlueskyVideoViewProps = {
   accessibilityHint?: string
   accessibilityLabel?: string
 
-  onActiveChange?: (e: NativeSyntheticEvent<{state: 'inactive' | 'staged' | 'active'}>) => void
+  onActiveChange?: (e: NativeSyntheticEvent<{isActive: boolean; state: 'inactive' | 'staged' | 'active'}>) => void
   onLoadingChange?: (e: NativeSyntheticEvent<{isLoading: boolean}>) => void
   onMutedChange?: (e: NativeSyntheticEvent<{isMuted: boolean}>) => void
   onPlayerPress?: () => void

--- a/src/BlueskyVideo.types.ts
+++ b/src/BlueskyVideo.types.ts
@@ -8,7 +8,7 @@ export type BlueskyVideoViewProps = {
   accessibilityHint?: string
   accessibilityLabel?: string
 
-  onActiveChange?: (e: NativeSyntheticEvent<{isActive: boolean}>) => void
+  onActiveChange?: (e: NativeSyntheticEvent<{state: 'inactive' | 'staged' | 'active'}>) => void
   onLoadingChange?: (e: NativeSyntheticEvent<{isLoading: boolean}>) => void
   onMutedChange?: (e: NativeSyntheticEvent<{isMuted: boolean}>) => void
   onPlayerPress?: () => void


### PR DESCRIPTION
Keeps 2 additional players alive in a staged state, so that they can start loading before they start playing. Videos are staged if they're on or below the screen

API change: `onActiveChanged` has changed from `{ isActive: boolean }` to `{  isActive: boolean, state: "active" | "inactive" | "staged" }`


https://github.com/user-attachments/assets/c067da25-ac95-481b-8cb6-8a966df2885e

## Test plan

- Confirm videos start loading as soon as they come on screen, or before. Confirm they only play when onscreen. Confirm you can't cause any funny behaviour, such as making 2 videos play at once
- Test in the bluesky app with branch `samuel/staged-videos`, confirm there's minimal flicker between states
- Confirm there's no issues with having so many players active at once. Slight concern I have is that the video feed tiktok mode uses a separate set of players, so theoretically we could have 6 alive at once maybe? Unsure if that's an issue, seemed fine to me