### PR TITLE
Preload AVAsset metadata and optimize play()

### DIFF
--- a/ios/VideoView.swift
+++ b/ios/VideoView.swift
@@ -358,7 +358,16 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
   // MARK: - controls
 
   private func play() {
-    self.player?.play()
+    if #available(iOS 16.0, *) {
+      let player = self.player
+      DispatchQueue.global(qos: .userInitiated).async {
+        player?.play()
+      }
+    } else {
+      DispatchQueue.main.async { [weak self] in
+        self?.player?.play()
+      }
+    }
     self.isPlaying = true
   }
 

--- a/ios/VideoView.swift
+++ b/ios/VideoView.swift
@@ -154,6 +154,7 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     self.isDestroyed = false
     self.isLoading = true
 
+    // Setup the view controller
     let pViewController = AVPlayerViewController()
     pViewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     pViewController.view.backgroundColor = .clear
@@ -177,8 +178,10 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
       return
     }
 
+    // Get a new player to use
     let player = PlayerManager.shared.dequeuePlayer()
 
+    // Get the player item and add it to the player
     let playerItem = AVPlayerItem(asset: asset)
     playerItem.preferredForwardBufferDuration = 5
 
@@ -200,23 +203,29 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
     self.ignoreAutoplay = false
 
+    // Fire final events
     self.pause()
     self.isLoading = false
 
+    // Remove periodic time observer
     if let periodicTimeObserver = self.periodicTimeObserver {
       player.removeTimeObserver(periodicTimeObserver)
       self.periodicTimeObserver = nil
     }
 
+    // Remove any observers from the player item
     if let playerItem = player.currentItem {
       removeObserversFromPlayerItem(playerItem)
     }
 
+    // Recycle the player
     PlayerManager.shared.recyclePlayer(player)
     self.player = nil
 
+    // Remove the player from the controller
     self.pViewController?.player = nil
 
+    // Remove the view controller
     self.pViewController?.view.removeFromSuperview()
     self.pViewController?.removeFromParent()
     self.pViewController = nil
@@ -227,6 +236,7 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
   }
 
   override func willMove(toWindow newWindow: UIWindow?) {
+    // Ignore anything that happens whenever we enter fullscreen. It's expected that the view will unmount here
     if self.isFullscreen {
       return
     }
@@ -253,12 +263,14 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     context: UnsafeMutableRawPointer?
   ) {
 
+    // This shouldn't happen, but just guard nil values
     guard let player = self.player,
       let playerItem = player.currentItem
     else {
       return
     }
 
+    // Status changes for the player item, i.e. for loading
     if keyPath == "status" {
       if playerItem.status == AVPlayerItem.Status.readyToPlay {
         self.isLoading = false

--- a/ios/VideoView.swift
+++ b/ios/VideoView.swift
@@ -121,21 +121,26 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
         let _ = try await asset.load(.duration, .tracks)
 
         guard !Task.isCancelled else { return }
-        guard let self else { return }
-        guard self.url == url else { return }
 
         await MainActor.run {
-          guard self.url == url else { return }
-          self.loadedAsset = asset
-          self.assetLoadingTask = nil
+          guard self?.url == url else { return }
+          self?.loadedAsset = asset
+          self?.assetLoadingTask = nil
 
-          if self.isViewActive && self.player == nil && self.pViewController != nil {
-            self.finishSetupIfReady()
+          if self?.isViewActive == true && self?.player == nil && self?.pViewController != nil {
+            self?.finishSetupIfReady()
           }
         }
       } catch {
+        guard !Task.isCancelled else { return }
         await MainActor.run {
+          guard self?.url == url else { return }
           self?.assetLoadingTask = nil
+          self?.isLoading = false
+          self?.onError([
+            "error": "Failed to load video",
+            "errorDescription": "\(error.localizedDescription)",
+          ])
         }
       }
     }
@@ -228,6 +233,8 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
     if newWindow == nil {
       ViewManager.shared.remove(self)
+      self.assetLoadingTask?.cancel()
+      self.assetLoadingTask = nil
       self.destroy()
     }
   }
@@ -359,9 +366,8 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
   private func play() {
     if #available(iOS 16.0, *) {
-      let player = self.player
-      DispatchQueue.global(qos: .userInitiated).async {
-        player?.play()
+      DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+        self?.player?.play()
       }
     } else {
       DispatchQueue.main.async { [weak self] in

--- a/ios/VideoView.swift
+++ b/ios/VideoView.swift
@@ -5,6 +5,8 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
   private var pViewController: AVPlayerViewController?
   private var player: AVPlayer?
   private var periodicTimeObserver: Any?
+  private var loadedAsset: AVAsset?
+  private var assetLoadingTask: Task<Void, Never>?
 
   // props
   var autoplay: Bool = true
@@ -13,6 +15,13 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     didSet {
       if url == nil || url == oldValue {
         return
+      }
+
+      self.assetLoadingTask?.cancel()
+      self.loadedAsset = nil
+
+      if let url = url {
+        self.startAssetLoading(for: url)
       }
 
       if self.isViewActive {
@@ -105,15 +114,41 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
   // MARK: - lifecycle
 
+  private func startAssetLoading(for url: URL) {
+    let asset = AVAsset(url: url)
+    self.assetLoadingTask = Task { [weak self] in
+      do {
+        let _ = try await asset.load(.duration, .tracks)
+
+        guard !Task.isCancelled else { return }
+        guard let self else { return }
+        guard self.url == url else { return }
+
+        await MainActor.run {
+          guard self.url == url else { return }
+          self.loadedAsset = asset
+          self.assetLoadingTask = nil
+
+          if self.isViewActive && self.player == nil && self.pViewController != nil {
+            self.finishSetupIfReady()
+          }
+        }
+      } catch {
+        await MainActor.run {
+          self?.assetLoadingTask = nil
+        }
+      }
+    }
+  }
+
   private func setup() {
-    guard let url = url, self.player == nil else {
+    guard url != nil, self.player == nil else {
       return
     }
 
     self.isDestroyed = false
     self.isLoading = true
 
-    // Setup the view controller
     let pViewController = AVPlayerViewController()
     pViewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     pViewController.view.backgroundColor = .clear
@@ -124,34 +159,31 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     if #available(iOS 16.0, *) {
       pViewController.allowsVideoFrameAnalysis = false
     }
+    self.addSubview(pViewController.view)
+    self.pViewController = pViewController
 
-    // Recycle the current player if there is one
-    if let currentPlayer = self.player {
-      PlayerManager.shared.recyclePlayer(currentPlayer)
+    self.finishSetupIfReady()
+  }
+
+  private func finishSetupIfReady() {
+    guard let asset = self.loadedAsset,
+          let pViewController = self.pViewController,
+          self.player == nil else {
+      return
     }
 
-    // Get a new player to use
     let player = PlayerManager.shared.dequeuePlayer()
 
-    // Add observers to the player
+    let playerItem = AVPlayerItem(asset: asset)
+    playerItem.preferredForwardBufferDuration = 5
+
+    self.addObserversToPlayerItem(playerItem)
+    player.replaceCurrentItem(with: playerItem)
+
     self.periodicTimeObserver = self.createPeriodicTimeObserver(player)
-
     pViewController.player = player
-    self.addSubview(pViewController.view)
 
-    self.pViewController = pViewController
     self.player = player
-
-    // Get the player item and add it to the player
-    DispatchQueue.global(qos: .background).async { [weak self] in
-      let playerItem = AVPlayerItem(url: url)
-      playerItem.preferredForwardBufferDuration = 5
-
-      DispatchQueue.main.async {
-        self?.player?.replaceCurrentItem(with: playerItem)
-        self?.addObserversToPlayerItem(playerItem)
-      }
-    }
   }
 
   private func destroy() {
@@ -163,29 +195,23 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
     self.ignoreAutoplay = false
 
-    // Fire final events
     self.pause()
     self.isLoading = false
 
-    // Remove period time observer and nil it
     if let periodicTimeObserver = self.periodicTimeObserver {
-      self.player?.removeTimeObserver(periodicTimeObserver)
+      player.removeTimeObserver(periodicTimeObserver)
       self.periodicTimeObserver = nil
     }
 
-    // Remove any observers from the player item and nil the item
-    if let playerItem = self.player?.currentItem {
+    if let playerItem = player.currentItem {
       removeObserversFromPlayerItem(playerItem)
     }
 
-    // Recycle the player and nil the player
     PlayerManager.shared.recyclePlayer(player)
     self.player = nil
 
-    // Remove the player from the controller
     self.pViewController?.player = nil
 
-    // Remove the view controller
     self.pViewController?.view.removeFromSuperview()
     self.pViewController?.removeFromParent()
     self.pViewController = nil
@@ -196,7 +222,6 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
   }
 
   override func willMove(toWindow newWindow: UIWindow?) {
-    // Ignore anything that happens whenever we enter fullscreen. It's expected that the view will unmount here
     if self.isFullscreen {
       return
     }
@@ -221,14 +246,12 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     context: UnsafeMutableRawPointer?
   ) {
 
-    // This shouldn't happen, but just guard nil values
     guard let player = self.player,
       let playerItem = player.currentItem
     else {
       return
     }
 
-    // status changes for the player item, i.e. for loading
     if keyPath == "status" {
       if playerItem.status == AVPlayerItem.Status.readyToPlay {
         self.isLoading = false
@@ -319,6 +342,10 @@ class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
     self.isViewActive = active
     if active {
+      if let url = self.url, self.loadedAsset == nil, self.assetLoadingTask == nil {
+        self.startAssetLoading(for: url)
+      }
+
       if self.autoplay || self.forceTakeover {
         self.setup()
       }


### PR DESCRIPTION
## Summary
- Preload AVAsset metadata (duration, tracks) when URL is set, before the view becomes active
- This prevents `replaceCurrentItem(with:)` from blocking the main thread while fetching metadata over the network
- Preserve loaded assets when scrolling away for instant reuse when scrolling back
- Move `play()` to background thread on iOS 16+ (where it's nonisolated)

## Test plan
- [ ] Run example app, scroll through video feed - should be smooth(er)
- [ ] Run `moveIt.sh` script and build social-app, then scroll through a video-heavy feed (i.e. Aaron Rupar's profile)

optional
- [ ] Test on iOS 15 device to verify fallback behavior
- [ ] Profile with Instruments - verify no main thread blocking during `replaceCurrentItem`

🤖 Generated with [Claude Code](https://claude.com/claude-code)